### PR TITLE
Support timestamps without microseconds

### DIFF
--- a/takproto/constants.py
+++ b/takproto/constants.py
@@ -34,8 +34,8 @@ __license__ = "Apache License, Version 2.0"
 DEFAULT_PROTO_HEADER = bytearray(b"\xbf")
 DEFAULT_MESH_HEADER = bytearray(b"\xbf\x01\xbf")
 
-W3C_XML_DATETIME: str = "%Y-%m-%dT%H:%M:%S.%fZ"
-ISO_8601_UTC = W3C_XML_DATETIME  # Issue 7: Not technically correct.
+W3C_XML_DATETIME: str = "%Y-%m-%dT%H:%M:%SZ"
+ISO_8601_UTC: str = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 
 class TAKProtoVer(Enum):

--- a/takproto/functions.py
+++ b/takproto/functions.py
@@ -35,6 +35,7 @@ import delimited_protobuf as dpb
 
 from takproto.constants import (
     ISO_8601_UTC,
+    W3C_XML_DATETIME,
     DEFAULT_MESH_HEADER,
     DEFAULT_PROTO_HEADER,
     TAKProtoVer,
@@ -70,7 +71,10 @@ def parse_stream(msg):
 
 def format_time(time: str) -> int:
     """Format timestamp as microseconds."""
-    s_time = datetime.strptime(time + "+0000", ISO_8601_UTC + "%z")
+    try:
+        s_time = datetime.strptime(time + "+0000", W3C_XML_DATETIME + "%z")
+    except ValueError:
+        s_time = datetime.strptime(time + "+0000", ISO_8601_UTC + "%z")
     return int(s_time.timestamp() * 1000)
 
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -47,6 +47,19 @@ class TestFunctions(unittest.TestCase):
         )
         self.assertEqual(time2, t_time)
 
+    def test_format_timestamp_without_subseconds(self):
+        """Test formatting timestamp to and from Protobuf format."""
+        t_time = "2020-02-08T18:10:44Z"
+        t_ts = 1581185444000
+        ts = takproto.format_time(t_time)
+        self.assertEqual(ts, t_ts)
+
+        t_ts2 = t_ts / 1000
+        time2 = datetime.fromtimestamp(t_ts2, timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        self.assertEqual(time2, t_time)
+
     def test_xml2proto_default(self):
         """Test encoding XML string as Protobuf bytearray."""
         t_xml = """<?xml version='1.0' encoding='UTF-8' standalone='yes'?>


### PR DESCRIPTION
Don't know which format to try first, but seems like going forward timestamps will have microseconds less often.
